### PR TITLE
make tag_release a job

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -46,4 +46,16 @@ jobs:
         with:          
           service-id: ${{ secrets.RENDER_SERVICE_ID }}
           api-key: ${{ secrets.RENDER_TOKEN }}
-                    
+  
+  tag_release:
+    needs: [simple_deployment_pipeline, deploy]
+    if: ${{ github.event_name == 'push'}}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.67.0 
+        env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+         DEFAULT_BUMP : patch    
+         WITH_V: true    


### PR DESCRIPTION
A job dependent on simple_deployment_pipeline and deploy jobs change the default bump to patch